### PR TITLE
Fix metrics-core-jars version to 2.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    multimeter (1.1.6-java)
+    multimeter (1.1.7-java)
       json
       metrics-core-jars
 

--- a/lib/multimeter/version.rb
+++ b/lib/multimeter/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Multimeter
-  VERSION = '1.1.6'
+  VERSION = '1.1.7'
 end

--- a/multimeter.gemspec
+++ b/multimeter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'multimeter'
   
-  s.add_dependency 'metrics-core-jars'
+  s.add_dependency 'metrics-core-jars', '~> 2.1.2'
   s.add_dependency 'json'
   
   s.files         = FileList['lib/**/*.rb'].to_a


### PR DESCRIPTION
Fix metrics-core-jars to version 2.1.2 since the gem has not been working since the upgrade to 3.0.2.
